### PR TITLE
Fix OS target wording

### DIFF
--- a/assets/func.sh
+++ b/assets/func.sh
@@ -5,7 +5,7 @@
 # This project allows running full-screen versions of
 # Apple's Mac OS 7, 8 and 9 with audio, active online
 # connection, and modem emulation under a CLI-only
-# Debian 32bit (i386) system.
+# Raspberry Pi OS (Legacy) 32-bit system.
 # --------------------------------------------------------
 # Author: Jaroslaw Mazurkiewicz  /  jaromaz
 # www: https://jm.iq.pl  e-mail: jm at iq.pl


### PR DESCRIPTION
## Summary
- clarify the supported OS in `assets/func.sh`

## Testing
- `bash -n assets/func.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841c19b2f7083299df8e02750cac685